### PR TITLE
Add convergence info fields to OZSolution struct

### DIFF
--- a/docs/src/Solvers.md
+++ b/docs/src/Solvers.md
@@ -11,12 +11,22 @@ For the implemented cases, `Exact` solves the system exactly, or throws an error
 Exact
 ```
 
-The methods `FourierIteration` and `NgIteration` both use recursive iteration to find improved estimates of the solution using Fourier Transforms. `NgIteration` uses a scheme to accelerate convergence, see Ref. [1]. 
+The methods `FourierIteration` and `NgIteration` both use recursive iteration to find improved estimates of the solution using Fourier Transforms. `NgIteration` uses a scheme to accelerate convergence, see Ref. [1].
 
 ```@docs
 FourierIteration
 NgIteration
 ```
+
+## Solution
+
+The `solve` function returns an [`OZSolution`](@ref) object containing both the solution data and convergence information:
+- `r`, `k`: grid points in real and reciprocal space
+- `gr`, `Sk`, `cr`, `ck`, `gamma_r`, `gamma_k`: correlation functions
+- `converged`: whether the solution converged (always `true`; failures throw exceptions)
+- `iterations`: number of iterations performed (0 for `Exact`)
+- `final_error`: final error at termination (0.0 for `Exact`)
+- `termination_reason`: `:converged` or `:exact`
 
 ## Meta-solvers
 

--- a/src/Solutions.jl
+++ b/src/Solutions.jl
@@ -2,24 +2,28 @@
 """
     OZSolution
 
-Holds the solution of an Ornstein Zernike problem. 
+Holds the solution of an Ornstein Zernike problem.
 
 Fields:
-- r: vector of distances
-- k: vector of wave numbers
-- gr: radial distribution function    
-- Sk: static structure factor
-- ck: direct correlation function in k space
-- cr: direct correlation function in real space
-- gamma_r: indirect correlation function in real space
-- gamma_k: indirect correlation function in k space
+- `r`: vector of distances
+- `k`: vector of wave numbers
+- `gr`: radial distribution function
+- `Sk`: static structure factor
+- `ck`: direct correlation function in k space
+- `cr`: direct correlation function in real space
+- `gamma_r`: indirect correlation function in real space
+- `gamma_k`: indirect correlation function in k space
+- `converged`: whether the solution converged (always `true`; failures throw exceptions)
+- `iterations`: number of iterations performed
+- `final_error`: final error at termination
+- `termination_reason`: reason for termination (`:converged` or `:exact`)
 
-if the system was a single-component system, `gr`, `Sk`, etc, are vectors. 
-If instead the system was a multicomponent one, they are three dimensional vectors, 
+if the system was a single-component system, `gr`, `Sk`, etc, are vectors.
+If instead the system was a multicomponent one, they are three dimensional vectors,
 where the first dimension contains the values along r, and the second and third dimension
 contain the data for the species.
 """
-struct OZSolution{T1,T2}
+struct OZSolution{T1,T2,T3}
     r::T1
     k::T1
     gr::T2
@@ -28,6 +32,10 @@ struct OZSolution{T1,T2}
     ck::T2
     gamma_r::T2
     gamma_k::T2
+    converged::Bool
+    iterations::Int
+    final_error::T3
+    termination_reason::Symbol
 end
 
 function convert_vecofmat_to_3darr(a::Vector{T}) where {T<:AbstractMatrix}
@@ -52,38 +60,40 @@ function find_g_from_c_and_γ(c::Vector{T}, γ::Vector{T}) where {T}
     return g
 end
 
-function find_S_from_ĉ_and_ρ(ĉ::Vector{T}, ρ) where {T<:Number}
-    return @. one(T) + ρ * ĉ / (one(T) - ρ * ĉ)
+function find_S_from_ĉ_and_ρ(ĉ::Vector{T}, ρ) where {T<:Number}
+    return @. one(T) + ρ * ĉ / (one(T) - ρ * ĉ)
 end
 
-function find_S_from_ĉ_and_ρ(ĉ::Vector{T}, ρ) where {T<:AbstractMatrix}
-    S = copy(ĉ)
+function find_S_from_ĉ_and_ρ(ĉ::Vector{T}, ρ) where {T<:AbstractMatrix}
+    S = copy(ĉ)
     ρtot = sum(ρ.diag)
     x = ρ.diag / ρtot
-    for i in eachindex(ĉ)
-        Si = inv(one(T) ./ x .- sum(ρ) * ĉ[i])
+    for i in eachindex(ĉ)
+        Si = inv(one(T) ./ x .- sum(ρ) * ĉ[i])
         S[i] = Si
     end
     return S
 end
 
 
-function construct_solution(r::T1, k::T1, cr::T, ck::T, gamma_r::T, gamma_k::T, ρ) where {T1,T<:Vector{<:AbstractMatrix}}
+function construct_solution(r::T1, k::T1, cr::T, ck::T, gamma_r::T, gamma_k::T, ρ;
+                            converged::Bool=true, iterations::Int=0, final_error=0.0, termination_reason::Symbol=:unknown) where {T1,T<:Vector{<:AbstractMatrix}}
     gr = find_g_from_c_and_γ(cr, gamma_r)
-    Sk = find_S_from_ĉ_and_ρ(ck, ρ)
+    Sk = find_S_from_ĉ_and_ρ(ck, ρ)
     gr = convert_vecofmat_to_3darr(gr)
     Sk = convert_vecofmat_to_3darr(Sk)
     ck = convert_vecofmat_to_3darr(ck)
     cr = convert_vecofmat_to_3darr(cr)
     gamma_r = convert_vecofmat_to_3darr(gamma_r)
     gamma_k = convert_vecofmat_to_3darr(gamma_k)
-    OZSolution(r, k, gr, Sk, cr, ck, gamma_r, gamma_k)
+    OZSolution(r, k, gr, Sk, cr, ck, gamma_r, gamma_k, converged, iterations, final_error, termination_reason)
 end
 
-function construct_solution(r::T1, k::T1, cr::T, ck::T, gamma_r::T, gamma_k::T, ρ) where {T1,T<:Vector{<:Number}}
+function construct_solution(r::T1, k::T1, cr::T, ck::T, gamma_r::T, gamma_k::T, ρ;
+                            converged::Bool=true, iterations::Int=0, final_error=0.0, termination_reason::Symbol=:unknown) where {T1,T<:Vector{<:Number}}
     gr = find_g_from_c_and_γ(cr, gamma_r)
-    Sk = find_S_from_ĉ_and_ρ(ck, ρ)
-    OZSolution(r, k, gr, Sk, cr, ck, gamma_r, gamma_k)
+    Sk = find_S_from_ĉ_and_ρ(ck, ρ)
+    OZSolution(r, k, gr, Sk, cr, ck, gamma_r, gamma_k, converged, iterations, final_error, termination_reason)
 end
 
 
@@ -101,7 +111,11 @@ function Base.show(io::IO, ::MIME"text/plain", p::OZSolution{T1,T2}) where {T1,T
     show(io, p.ck')
     print(io, "'\n Sk = ")
     show(io, p.Sk')
-    print("' \n")
+    print(io, "'\n converged = ", p.converged)
+    print(io, "\n iterations = ", p.iterations)
+    print(io, "\n final_error = ", p.final_error)
+    print(io, "\n termination_reason = ", p.termination_reason)
+    print("\n")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", p::OZSolution{T1,T2}) where {T1,T2<:AbstractArray}
@@ -118,5 +132,9 @@ function Base.show(io::IO, ::MIME"text/plain", p::OZSolution{T1,T2}) where {T1,T
     show(io, p.ck)
     print(io, "\n Sk = ")
     show(io, p.Sk)
+    print(io, "\n converged = ", p.converged)
+    print(io, "\n iterations = ", p.iterations)
+    print(io, "\n final_error = ", p.final_error)
+    print(io, "\n termination_reason = ", p.termination_reason)
     print("\n")
 end

--- a/src/Solutions.jl
+++ b/src/Solutions.jl
@@ -136,5 +136,5 @@ function Base.show(io::IO, ::MIME"text/plain", p::OZSolution{T1,T2}) where {T1,T
     print(io, "\n iterations = ", p.iterations)
     print(io, "\n final_error = ", p.final_error)
     print(io, "\n termination_reason = ", p.termination_reason)
-    print("\n")
+    print(io, "\n")
 end

--- a/src/Solutions.jl
+++ b/src/Solutions.jl
@@ -115,7 +115,7 @@ function Base.show(io::IO, ::MIME"text/plain", p::OZSolution{T1,T2}) where {T1,T
     print(io, "\n iterations = ", p.iterations)
     print(io, "\n final_error = ", p.final_error)
     print(io, "\n termination_reason = ", p.termination_reason)
-    print("\n")
+    print(io, "\n")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", p::OZSolution{T1,T2}) where {T1,T2<:AbstractArray}

--- a/src/Solvers/Exact.jl
+++ b/src/Solvers/Exact.jl
@@ -25,7 +25,7 @@ function find_Ck_1dPYSC_exact(η, k)
     return Ck
 end
 
-function find_Cr_1dPYSC_exact(η, r) 
+function find_Cr_1dPYSC_exact(η, r)
     Q0 = -1/(1-η)
     c0 = -Q0^2
     c1 = η * Q0^2
@@ -35,10 +35,10 @@ function find_Cr_1dPYSC_exact(η, r)
 end
 
 function find_Ck_5dPYSC_exact(η, k)
-    T = 1+18η+6η^2 
-    Q0 = 1/(120η*(1-η)^3)*(1-33η-87η^2-6η^3-T^(3/2))   
-    Q1 = -1/(12*(1-η)^3)*((3+2η)*T^(1/2) + 3+19η+3η^2)   
-    Q2 =-T^(1/2)/(24(1-η)^3)*(2+3η+T^(1/2))   
+    T = 1+18η+6η^2
+    Q0 = 1/(120η*(1-η)^3)*(1-33η-87η^2-6η^3-T^(3/2))
+    Q1 = -1/(12*(1-η)^3)*((3+2η)*T^(1/2) + 3+19η+3η^2)
+    Q2 =-T^(1/2)/(24(1-η)^3)*(2+3η+T^(1/2))
 
     Q̃0 = -8Q2
     c0 = -(Q̃0)^2
@@ -46,21 +46,21 @@ function find_Ck_5dPYSC_exact(η, k)
     c3 = 20η*(8Q0*Q2-3Q1^2)
     c5 = -3/8*η*c0
     Ck = @. -(1/(k^10))*
-        8*π^2 * (8 * (720c5 - 18c3 * k^2 + c1 * k^4) + (-5760c5 + 
-        144*(c3 + 20c5) * k^2 - 8*(c1 + 9c3 + 30c5) * k^4 
-        + (3c0 + 4c1 + 6c3 + 8c5) * k^6)*cos(k) + 
-        k * (-5760c5 + 48*(3c3 + 20c5) * k^2 - 
-        (3c0 + 8*(c1 + 3c3 + 6c5)) * k^4 + 
+        8*π^2 * (8 * (720c5 - 18c3 * k^2 + c1 * k^4) + (-5760c5 +
+        144*(c3 + 20c5) * k^2 - 8*(c1 + 9c3 + 30c5) * k^4
+        + (3c0 + 4c1 + 6c3 + 8c5) * k^6)*cos(k) +
+        k * (-5760c5 + 48*(3c3 + 20c5) * k^2 -
+        (3c0 + 8*(c1 + 3c3 + 6c5)) * k^4 +
         (c0 + c1 + c3 + c5) * k^6) * sin(k))
 
     return Ck
 end
 
 function find_Cr_5dPYSC_exact(η, r)
-    T = 1+18η+6η^2 
-    Q0 = 1/(120η*(1-η)^3)*(1-33η-87η^2-6η^3-T^(3/2))   
-    Q1 = -1/(12*(1-η)^3)*((3+2η)*T^(1/2) + 3+19η+3η^2)   
-    Q2 =-T^(1/2)/(24(1-η)^3)*(2+3η+T^(1/2))   
+    T = 1+18η+6η^2
+    Q0 = 1/(120η*(1-η)^3)*(1-33η-87η^2-6η^3-T^(3/2))
+    Q1 = -1/(12*(1-η)^3)*((3+2η)*T^(1/2) + 3+19η+3η^2)
+    Q2 =-T^(1/2)/(24(1-η)^3)*(2+3η+T^(1/2))
 
     Q̃0 = -8Q2
     c0 = -(Q̃0)^2
@@ -99,8 +99,8 @@ function solve(system::SimpleFluid{3, T1, T2, HardSpheres{T3}}, ::PercusYevick, 
 
     gr = @. Cr + γmulr / r + 1
     gr[r.<1.0] .= 0.0
-    
-    return OZSolution(r, k, gr, Sk, Cr, Ck, γmulr ./ r, γmulk ./ k)
+
+    return OZSolution(r, k, gr, Sk, Cr, Ck, γmulr ./ r, γmulk ./ k, true, 0, 0.0, :exact)
 end
 
 function solve(system::SimpleFluid{1, T1, T2, HardSpheres{T3}}, ::PercusYevick, method::Exact) where {T1,T2,T3}
@@ -117,7 +117,7 @@ function solve(system::SimpleFluid{1, T1, T2, HardSpheres{T3}}, ::PercusYevick, 
     r, k = fourierplan.r, fourierplan.k
 
     ρ = system.ρ
-    η = ρ 
+    η = ρ
 
     # baxter
     Cr = find_Cr_1dPYSC_exact(η, r)
@@ -134,7 +134,7 @@ function solve(system::SimpleFluid{1, T1, T2, HardSpheres{T3}}, ::PercusYevick, 
 
     gr = @. Cr + γmulr / r + 1
     gr[r.<1.0] .= 0.0
-    return OZSolution(r, k, gr, Sk, Cr, Ck, γmulr ./ r, γmulk ./ k)
+    return OZSolution(r, k, gr, Sk, Cr, Ck, γmulr ./ r, γmulk ./ k, true, 0, 0.0, :exact)
 end
 
 function solve(system::SimpleFluid{5, T1, T2, HardSpheres{T3}}, ::PercusYevick, method::Exact) where {T1,T2,T3}
@@ -166,7 +166,7 @@ function solve(system::SimpleFluid{5, T1, T2, HardSpheres{T3}}, ::PercusYevick, 
 
     gr = @. Cr + γmulr / r + 1
     gr[r.<1.0] .= 0.0
-    return OZSolution(r, k, gr, Sk, Cr, Ck, γmulr ./ r, γmulk ./ k)
+    return OZSolution(r, k, gr, Sk, Cr, Ck, γmulr ./ r, γmulk ./ k, true, 0, 0.0, :exact)
 end
 
 
@@ -180,7 +180,7 @@ function solve_3dPYMC_exact(ρ, diameters, kᵢ::Number)
     a = [(1 - ξ[3])^(-2) * (1 - ξ[3] + 3 * ξ[2] * d[i, i]) for i = 1:p]
     b = [-3 / 2 * d[i, i]^2 * (1 - ξ[3])^(-2) * ξ[2] for i = 1:p]
     Q̃ = zeros(ComplexF64, Ns, Ns)
-    
+
     #analytical solution of integrals
     for μ = 1:Ns, ν = 1:Ns
         I0 = -1im / kᵢ * (cis(kᵢ * d[μ, ν]) - cis(kᵢ * s[μ, ν]))
@@ -240,5 +240,5 @@ function solve(system::SimpleMixture{3, species, T1, T2, HardSpheres{T3}}, ::Per
     end
     γr = gr .- Cr .- 1.0
     γk = Hk .- Ck
-    return OZSolution(r, k, gr, Sk, Cr, Ck, γr, γk)
+    return OZSolution(r, k, gr, Sk, Cr, Ck, γr, γk, true, 0, 0.0, :exact)
 end

--- a/src/Solvers/NgIteration.jl
+++ b/src/Solvers/NgIteration.jl
@@ -9,8 +9,8 @@ function solve(system::SimpleUnchargedSystem, closure::Closure, method::NgIterat
 
     renorm = uses_renormalized_gamma(closure)
     cache = OZSolverCache(system, method, renorm)
-    mayer_f, fourierplan, r, k, βu_disp_tail, βu, Γhat, C, Ĉ, Γ_new = 
-        cache.mayer_f, cache.fourierplan, cache.r, cache.k, cache.βu_dispersion_tail, cache.βu, cache.Γhat, cache.C, cache.Ĉ, cache.Γ_new
+    mayer_f, fourierplan, r, k, βu_disp_tail, βu, Γhat, C, Ĉ, Γ_new =
+        cache.mayer_f, cache.fourierplan, cache.r, cache.k, cache.βu_dispersion_tail, cache.βu, cache.Γhat, cache.C, cache.Ĉ, cache.Γ_new
 
     T = eltype(mayer_f)
     TT = T <: Number ? T : eltype(T)
@@ -18,7 +18,7 @@ function solve(system::SimpleUnchargedSystem, closure::Closure, method::NgIterat
     b = zeros(TT, N_stages)
 
     # if T <: AbstractMatrix, we need to store gi as a vector of matrices
-    # if T <: Number, we need to store gi as a vectors of numbers 
+    # if T <: Number, we need to store gi as a vectors of numbers
     gn_full = [copy(mayer_f) for _ in 1:N_stages+1] # first element is g_n, second is g_{n-1} etc
     fn_full = [copy(mayer_f) for _ in 1:N_stages+1]
     dn_full = [copy(mayer_f) for _ in 1:N_stages+1]
@@ -45,11 +45,11 @@ function solve(system::SimpleUnchargedSystem, closure::Closure, method::NgIterat
 
     err = tolerance * 2
     iteration = 0
-    # first bootstrapping steps 
+    # first bootstrapping steps
     for stage = reverse(1:N_stages)
         ctx_stage = UnchargedClosureEvalContext(r, mayer_f, fn_full[stage+1], βu, βu_disp_tail)
         closure_apply!(C, closure, ctx_stage)
-        oz_iteration_step!(C, Ĉ, Γhat, gn_full[stage+1], ρ, fourierplan)
+        oz_iteration_step!(C, Ĉ, Γhat, gn_full[stage+1], ρ, fourierplan)
         fn_flat[stage] .= gn_flat[stage+1]
     end
 
@@ -59,7 +59,7 @@ function solve(system::SimpleUnchargedSystem, closure::Closure, method::NgIterat
         end
         ctx_iter = UnchargedClosureEvalContext(r, mayer_f, fn_full[1], βu, βu_disp_tail)
         closure_apply!(C, closure, ctx_iter)
-        oz_iteration_step!(C, Ĉ, Γhat, Γ_new, ρ, fourierplan)
+        oz_iteration_step!(C, Ĉ, Γhat, Γ_new, ρ, fourierplan)
         gn_flat[1] .= Γ_new_flat
         err = compute_error(gn_flat[1], fn_flat[1])
         if method.verbose && iteration % 10 == 0
@@ -90,10 +90,10 @@ function solve(system::SimpleUnchargedSystem, closure::Closure, method::NgIterat
         println("the error is $(round(err, digits=ceil(Int, 1-log10(err)))).")
     end
     c = C ./ r
-    ĉ = Ĉ ./ k
+    ĉ = Ĉ ./ k
     γ = Γ_new ./ r
     γ̂ = Γhat ./ k
-    return construct_solution(r, k, c, ĉ, γ, γ̂, ρ)
+    return construct_solution(r, k, c, ĉ, γ, γ̂, ρ; iterations=iteration, final_error=err, termination_reason=:converged)
 end
 
 
@@ -104,14 +104,14 @@ function solve(system::SimpleChargedSystem, closure::Closure, method::NgIteratio
 
     renorm = uses_renormalized_gamma(closure)
     cache = OZSolverCache(base_of(system), method, renorm)
-    mayer_f, fourierplan, r, k, βu_LR_disp, βu, Γ_SR_hat, C_SR, C_SR_hat, Γ_SR_new = 
-        cache.mayer_f, cache.fourierplan, cache.r, cache.k, cache.βu_dispersion_tail, cache.βu, cache.Γhat, cache.C, cache.Ĉ, cache.Γ_new
+    mayer_f, fourierplan, r, k, βu_LR_disp, βu, Γ_SR_hat, C_SR, C_SR_hat, Γ_SR_new =
+        cache.mayer_f, cache.fourierplan, cache.r, cache.k, cache.βu_dispersion_tail, cache.βu, cache.Γhat, cache.C, cache.Ĉ, cache.Γ_new
 
     βu_SR_coul, βu_LR_coul = split_coulomb_potential(r, system, coulombsplitting)
     βu = βu .+ βu_SR_coul .+ βu_LR_coul
     mayer_f .= find_mayer_f_function.(βu)
 
-    φ = -βu_LR_coul # long range part of c 
+    φ = -βu_LR_coul # long range part of c
     Φ_hat = fourier(φ .* r, fourierplan)  # note that the FT work on the "mulr" functions
     φ_hat = Φ_hat ./ k
 
@@ -121,7 +121,7 @@ function solve(system::SimpleChargedSystem, closure::Closure, method::NgIteratio
     q = Q ./ r
 
     # capital letters are multiplied by r or k
-    C_hat = 0.0copy(mayer_f); Γ_hat = 0.0copy(mayer_f) 
+    C_hat = 0.0copy(mayer_f); Γ_hat = 0.0copy(mayer_f)
 
     T = eltype(mayer_f)
     TT = T <: Number ? T : eltype(T)
@@ -129,7 +129,7 @@ function solve(system::SimpleChargedSystem, closure::Closure, method::NgIteratio
     b = zeros(TT, N_stages)
 
     # if T <: AbstractMatrix, we need to store gi as a vector of matrices
-    # if T <: Number, we need to store gi as a vectors of numbers 
+    # if T <: Number, we need to store gi as a vectors of numbers
     gn_full = [copy(mayer_f) for _ in 1:N_stages+1] # first element is g_n, second is g_{n-1} etc
     fn_full = [copy(mayer_f) for _ in 1:N_stages+1]
     dn_full = [copy(mayer_f) for _ in 1:N_stages+1]
@@ -156,16 +156,16 @@ function solve(system::SimpleChargedSystem, closure::Closure, method::NgIteratio
 
     err = tolerance * 2
     iteration = 0
-    # first bootstrapping steps 
+    # first bootstrapping steps
     for stage = reverse(1:N_stages)
         ctx_stage = ChargedClosureEvalContext(r, mayer_f, fn_full[stage+1], βu, βu_LR_disp, βu_LR_coul, q)
         closure_apply!(C_SR, closure, ctx_stage)
         fourier!(C_SR_hat, C_SR, fourierplan)
         C_hat .= C_SR_hat .+ Φ_hat
         for ik in eachindex(Γ_hat)
-            Γ_hat[ik] = (I*k[ik] - C_hat[ik] * ρ) \ (C_hat[ik] * ρ * C_hat[ik]) 
+            Γ_hat[ik] = (I*k[ik] - C_hat[ik] * ρ) \ (C_hat[ik] * ρ * C_hat[ik])
         end
-        Γ_SR_hat .= Γ_hat .- (Q_hat .- Φ_hat) 
+        Γ_SR_hat .= Γ_hat .- (Q_hat .- Φ_hat)
         inverse_fourier!(gn_full[stage+1], Γ_SR_hat, fourierplan)
         fn_flat[stage] .= gn_flat[stage+1]
     end
@@ -180,9 +180,9 @@ function solve(system::SimpleChargedSystem, closure::Closure, method::NgIteratio
         fourier!(C_SR_hat, C_SR, fourierplan)
         C_hat .= C_SR_hat .+ Φ_hat
         for ik in eachindex(Γ_hat)
-            Γ_hat[ik] = (I*k[ik] - C_hat[ik] * ρ) \ (C_hat[ik] * ρ * C_hat[ik]) 
+            Γ_hat[ik] = (I*k[ik] - C_hat[ik] * ρ) \ (C_hat[ik] * ρ * C_hat[ik])
         end
-        Γ_SR_hat .= Γ_hat .- (Q_hat .- Φ_hat) 
+        Γ_SR_hat .= Γ_hat .- (Q_hat .- Φ_hat)
         inverse_fourier!(Γ_SR_new, Γ_SR_hat, fourierplan)
 
         gn_flat[1] .= Γ_SR_new_flat
@@ -215,10 +215,10 @@ function solve(system::SimpleChargedSystem, closure::Closure, method::NgIteratio
         println("the error is $(round(err, digits=ceil(Int, 1-log10(err)))).")
     end
     c = C_SR ./ r + φ
-    ĉ = C_SR_hat ./ k + φ_hat
+    ĉ = C_SR_hat ./ k + φ_hat
     γ = Γ_SR_new ./ r + q - φ
     γ̂ = Γ_SR_hat ./ k + q_hat - φ_hat
-    return construct_solution(r, k, c, ĉ, γ, γ̂, ρ)
+    return construct_solution(r, k, c, ĉ, γ, γ̂, ρ; iterations=iteration, final_error=err, termination_reason=:converged)
 end
 
 
@@ -269,7 +269,7 @@ function find_Ng_coefficients(A::Matrix{T}, b::Vector{T}, N_stages, d0n::Vector{
     return coeffs
 end
 
-function inner(u::AbstractArray, v::AbstractArray, r) 
+function inner(u::AbstractArray, v::AbstractArray, r)
     @assert eltype(u) <: Number
     T = eltype(u)
     @assert length(u) == length(v)

--- a/test/test_FourierIteration_HS.jl
+++ b/test/test_FourierIteration_HS.jl
@@ -21,6 +21,17 @@ function test1()
     @test all(abs.(sol.ck .- sol2.ck) .< 1.0)
     @test all(abs.(sol.Sk .- sol2.Sk) .< atol)
 
+    # Check convergence info for FourierIteration
+    @test sol.converged == true
+    @test sol.iterations > 0
+    @test sol.final_error < 10^-10
+    @test sol.termination_reason == :converged
+
+    # Check convergence info for Exact
+    @test sol2.converged == true
+    @test sol2.iterations == 0
+    @test sol2.final_error == 0.0
+    @test sol2.termination_reason == :exact
 
     M = 1000
     ρ = [0.1, 0.2, 0.12]

--- a/test/test_NgIteration_HS.jl
+++ b/test/test_NgIteration_HS.jl
@@ -15,11 +15,22 @@ sol2 = solve(system, closure, Exact(M=M, dr=dr))
 
 atol = 0.1
 
-@test all((abs.(sol.cr .- sol2.cr)) .< atol) 
-@test all((abs.(sol.gr .- sol2.gr)) .< atol) 
-@test all((abs.(sol.ck .- sol2.ck)) .< atol) 
-@test all((abs.(sol.Sk .- sol2.Sk)) .< atol) 
+@test all((abs.(sol.cr .- sol2.cr)) .< atol)
+@test all((abs.(sol.gr .- sol2.gr)) .< atol)
+@test all((abs.(sol.ck .- sol2.ck)) .< atol)
+@test all((abs.(sol.Sk .- sol2.Sk)) .< atol)
 
+# Check convergence info for NgIteration
+@test sol.converged == true
+@test sol.iterations > 0
+@test sol.final_error < 10^-10
+@test sol.termination_reason == :converged
+
+# Check convergence info for Exact
+@test sol2.converged == true
+@test sol2.iterations == 0
+@test sol2.final_error == 0.0
+@test sol2.termination_reason == :exact
 
 M = 2000
 dr = 5.0/M


### PR DESCRIPTION
Add convergence info fields to OZSolution struct

Resolve #27

# Changes
Add fields directly to OZSolution
- converged: Bool (always true; failures throw exceptions)
- iterations: Int (0 for Exact solver)
- final_error: T3 (0.0 for Exact solver)
- termination_reason: Symbol (:converged or :exact)

Updated solvers (NgIteration, FourierIteration, Exact), tests, and documentation.